### PR TITLE
Automatically load AMP pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Amplifier AMP/Canonical switcher Chrome Extension
 
 This extension is designed for developers working with the AMP (Accelerated Mobile Pages) standard.  It detects AMP links
 in the page header and allows quick switching between the AMP and Canonical version of a page.  Optionally AMP pages can be loaded
-with the AMP validation enabled (#development=1).
+with the AMP validation enabled (`#development=1`).
 
-See http://www.ampproject.org/ and https://github.com/ampproject
+See https://www.ampproject.org/ and https://github.com/ampproject

--- a/amplified.js
+++ b/amplified.js
@@ -1,13 +1,19 @@
-(function() {
+setTimeout(function () {
+    var amphtml = document.querySelector("html[amp], html[⚡]");
     var amplink = document.querySelector("link[rel='amphtml']");
     var canonical = document.querySelector("link[rel='canonical']");
 
     var amp = {
         sentinel: "__AMPLIFIER__",
-        ampurl : (amplink !== null) ? amplink.href : null,
-        canonical : (canonical !== null) ? canonical.href : null,
-        isamp : (document.querySelector("html[amp], html[⚡]") !== null)
+        ampurl: (amplink !== null) ? amplink.href : null,
+        canonical: (canonical !== null) ? canonical.href : null,
+        isamp: amphtml !== null,
+        noredirect: location.hash === "#noredirect=1"
     };
 
-    chrome.runtime.sendMessage(amp);
-})();
+    chrome.runtime.sendMessage(amp, function (response) {
+        if (response && response.stop) {
+            stop();
+        }
+    });
+}, 0);

--- a/amplified.js
+++ b/amplified.js
@@ -1,23 +1,13 @@
 (function() {
     var amplink = document.querySelector("link[rel='amphtml']");
     var canonical = document.querySelector("link[rel='canonical']");
-    
-    var  amp = {
+
+    var amp = {
         sentinel: "__AMPLIFIER__",
-        ampurl : null,
-        canonical : null,
-        isamp : (document.querySelector("html[amp]") !== null ||  document.querySelector("html[⚡]") !== null)
+        ampurl : (amplink !== null) ? amplink.href : null,
+        canonical : (canonical !== null) ? canonical.href : null,
+        isamp : (document.querySelector("html[amp], html[⚡]") !== null)
     };
 
-    if (amplink !== null) {
-        amp.ampurl = amplink.href;
-        
-    }
-    if (canonical !== null) {
-        amp.canonical = canonical.href;
-    }
-   
-    
     chrome.runtime.sendMessage(amp);
-
 })();

--- a/background.js
+++ b/background.js
@@ -1,40 +1,47 @@
 // By John Pettitt
 // Crreative Commons CC(0)  Plublic domain
 
-var ampTabs = [];
-
+var ampTabs = {};
 
 chrome.runtime.onMessage.addListener(function(amp, sender, sendResponse) {
-    if (amp.sentinel === undefined || amp.sentinel != "__AMPLIFIER__") {
-      return;  //not from amplifier
-    }
-    if (amp.isamp) {
-      chrome.pageAction.setIcon({tabId:sender.tab.id, path: 'canonical.png'});
-      chrome.pageAction.setTitle({tabId:sender.tab.id, title: 'Show the Canonical version of this page'});
+  if (amp.sentinel === undefined || amp.sentinel !== "__AMPLIFIER__") {
+    return;  //not from amplifier
+  }
+
+  if (amp.isamp) {
+    chrome.pageAction.setIcon({tabId: sender.tab.id, path: 'canonical.png'});
+    chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'Show the Canonical version of this page'});
+  } else {
+    if (amp.ampurl !== null) {
+      chrome.pageAction.setIcon({tabId: sender.tab.id, path: 'amplify.png'});
+      chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'Show the AMP version of this page'});
     } else {
-      chrome.pageAction.setIcon({tabId:sender.tab.id, path: 'amplify.png'});
-      chrome.pageAction.setTitle({tabId:sender.tab.id, title: 'Show the AMP version of this page'});
+      chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'AMP version not detected'});
     }
-    if(amp.ampurl !== null || (amp.canonical !=null && amp.isamp)) {
-      chrome.pageAction.show(sender.tab.id);
-    }
-    ampTabs[sender.tab.id] = amp;
-    
-    if (localStorage["devMode"] == "true") {
-      amp.ampurl += "#development=1";
-    }
-   
+  }
+
+  if (amp.ampurl !== null || (amp.canonical !== null && amp.isamp)) {
+    chrome.pageAction.show(sender.tab.id);
+  }
+
+  ampTabs[sender.tab.id] = amp;
+
+  if (localStorage["devMode"] == "true") {
+    amp.ampurl += "#development=1";
+  }
 });
 
-//
-chrome.pageAction.onClicked.addListener(function(tab){
+chrome.tabs.onRemoved.addListener(function(tabId) {
+  delete ampTabs[tabId];
+});
+
+chrome.pageAction.onClicked.addListener(function(tab) {
   var amp = ampTabs[tab.id];
   if (amp.isamp) {
-    if (amp.canonical != null) {
+    if (amp.canonical !== null) {
       chrome.tabs.update(tab.id, { url: amp.canonical });
-    }   
+    }
   } else {
     chrome.tabs.update(tab.id, { url: amp.ampurl });
   }
 });
-

--- a/background.js
+++ b/background.js
@@ -1,47 +1,51 @@
-// By John Pettitt
-// Crreative Commons CC(0)  Plublic domain
+// By John Pettitt & Timothy Cyrus & Jerzy Głowacki
+// Creative Commons CC(0) Public domain
 
 var ampTabs = {};
 
-chrome.runtime.onMessage.addListener(function(amp, sender, sendResponse) {
-  if (amp.sentinel === undefined || amp.sentinel !== "__AMPLIFIER__") {
-    return;  //not from amplifier
-  }
+chrome.runtime.onMessage.addListener(function (amp, sender, sendResponse) {
+    if (amp.sentinel !== "__AMPLIFIER__") {
+        return; //not from amplifier
+    }
 
-  if (amp.isamp) {
-    chrome.pageAction.setIcon({tabId: sender.tab.id, path: 'canonical.png'});
-    chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'Show the Canonical version of this page'});
-  } else {
-    if (amp.ampurl !== null) {
-      chrome.pageAction.setIcon({tabId: sender.tab.id, path: 'amplify.png'});
-      chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'Show the AMP version of this page'});
+    if (amp.isamp) {
+        chrome.pageAction.setIcon({tabId: sender.tab.id, path: 'canonical.png'});
+        chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'Show the Canonical version of this page'});
+    } else if (amp.ampurl !== null) {
+        chrome.pageAction.setIcon({tabId: sender.tab.id, path: 'amplify.png'});
+        chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'Show the AMP version of this page'});
     } else {
-      chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'AMP version not detected'});
+        chrome.pageAction.setTitle({tabId: sender.tab.id, title: 'AMP version not detected'});
     }
-  }
 
-  if (amp.ampurl !== null || (amp.canonical !== null && amp.isamp)) {
-    chrome.pageAction.show(sender.tab.id);
-  }
+    if (amp.ampurl !== null || (amp.isamp && amp.canonical !== null)) {
+        chrome.pageAction.show(sender.tab.id);
+    }
 
-  ampTabs[sender.tab.id] = amp;
+    ampTabs[sender.tab.id] = amp;
 
-  if (localStorage["devMode"] == "true") {
-    amp.ampurl += "#development=1";
-  }
+    if (localStorage.getItem("devMode") === "true") {
+        amp.ampurl += "#development=1";
+    }
+
+    if (localStorage.getItem("autoMode") === "true") {
+        amp.canonical += "#noredirect=1";
+        if (!amp.isamp && !amp.noredirect && amp.ampurl !== null) {
+            sendResponse({stop: true});
+            chrome.tabs.update(sender.tab.id, {url: amp.ampurl});
+        }
+    }
 });
 
-chrome.tabs.onRemoved.addListener(function(tabId) {
-  delete ampTabs[tabId];
+chrome.tabs.onRemoved.addListener(function (tabId) {
+    delete ampTabs[tabId];
 });
 
-chrome.pageAction.onClicked.addListener(function(tab) {
-  var amp = ampTabs[tab.id];
-  if (amp.isamp) {
-    if (amp.canonical !== null) {
-      chrome.tabs.update(tab.id, { url: amp.canonical });
+chrome.pageAction.onClicked.addListener(function (tab) {
+    var amp = ampTabs[tab.id];
+    if (amp.isamp && amp.canonical !== null) {
+        chrome.tabs.update(tab.id, {url: amp.canonical});
+    } else {
+        chrome.tabs.update(tab.id, {url: amp.ampurl});
     }
-  } else {
-    chrome.tabs.update(tab.id, { url: amp.ampurl });
-  }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -3,26 +3,33 @@
   "name": "Amplifier  AMP/Canonical switcher",
   "short_name": "Amplifier",
   "description": "Quickly switch between Canonical and AMP version of a page",
-  "version": "0.0.5",
-  "author": "John Pettitt",
+  "version": "0.0.6",
+  "author": "John Pettitt & Timothy Cyrus & Jerzy Głowacki",
   "icons": {
     "48": "amplifier48.png",
     "128": "amplifier128.png"
   },
   "background": {
-    "scripts": ["background.js"],
+    "scripts": [
+      "background.js"
+    ],
     "persistent": true
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*","https://*/*"],
-      "js": ["amplified.js"],
-      "run_at": "document_end"
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "amplified.js"
+      ],
+      "run_at": "document_start"
     }
   ],
   "page_action": {
     "default_icon": "switcher.png",
     "default_title": "AMP version not detected"
   },
-  "options_page" : "options.html"
+  "options_page": "options.html"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,14 +2,14 @@
   "manifest_version": 2,
   "name": "Amplifier  AMP/Canonical switcher",
   "short_name": "Amplifier",
-  "description": "Quickly switch between canonical and AMP version of a page",
+  "description": "Quickly switch between Canonical and AMP version of a page",
   "version": "0.0.5",
   "author": "John Pettitt",
-  "icons": { 
-           "48": "amplifier48.png",
-          "128": "amplifier128.png" 
+  "icons": {
+    "48": "amplifier48.png",
+    "128": "amplifier128.png"
   },
-  "background" : {
+  "background": {
     "scripts": ["background.js"],
     "persistent": true
   },
@@ -17,13 +17,12 @@
     {
       "matches": ["http://*/*","https://*/*"],
       "js": ["amplified.js"],
-      "run_at" : "document_end"
+      "run_at": "document_end"
     }
   ],
-  "page_action" :
-  {
-    "default_icon" : "switcher.png",
-    "default_title" : "AMP version not detected."
+  "page_action": {
+    "default_icon": "switcher.png",
+    "default_title": "AMP version not detected."
   },
   "options_page" : "options.html"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
   ],
   "page_action": {
     "default_icon": "switcher.png",
-    "default_title": "AMP version not detected."
+    "default_title": "AMP version not detected"
   },
   "options_page" : "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -7,7 +7,7 @@
 <body>
 	<h1>Options for Amplifier AMP switcher.</h1>
 	<label for="devmode">Load AMP pages in developer mode</label>
-        <input type="checkbox" id="devmode">
-        <script type="text/javascript" src="options.js"></script>
+  <input type="checkbox" id="devmode">
+  <script type="text/javascript" src="options.js"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
-
 <html>
 <head>
-	<title>Options for Amplifier AMP switcher.</title>
+	<title>Options for Amplifier AMP switcher</title>
 </head>
 <body>
-	<h1>Options for Amplifier AMP switcher.</h1>
-	<label for="devmode">Load AMP pages in developer mode</label>
-  <input type="checkbox" id="devmode">
-  <script type="text/javascript" src="options.js"></script>
+	<h1>Options for Amplifier AMP switcher:</h1>
+	<p><label><input type="checkbox" id="automode"> Load AMP pages automatically</label></p>
+	<p><label><input type="checkbox" id="devmode"> Load AMP pages in developer mode</label></p>
+    <script type="text/javascript" src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -1,7 +1,12 @@
+var automode = document.getElementById("automode");
 var devmode = document.getElementById("devmode");
 
-devmode.checked = (localStorage["devMode"] == "true"); // local storage stringifies things
+automode.checked = localStorage.getItem("autoMode") === "true";
+devmode.checked = localStorage.getItem("devMode") === "true";
 
-devmode.addEventListener("change", function() {
-	localStorage["devMode"] = this.checked;
+automode.addEventListener("change", function () {
+    localStorage.setItem("autoMode", this.checked);
+});
+devmode.addEventListener("change", function () {
+    localStorage.setItem("devMode", this.checked);
 });

--- a/options.js
+++ b/options.js
@@ -1,13 +1,7 @@
+var devmode = document.getElementById("devmode");
 
+devmode.checked = (localStorage["devMode"] == "true"); // local storage stringifies things
 
-
-
-document.getElementById("devmode").checked = (localStorage["devMode"] == "true"); // local storage stringifies things
-
-
-
-
-
-document.getElementById("devmode").addEventListener("change",function() {
-	localStorage["devMode"] = this.checked;	
+devmode.addEventListener("change", function() {
+	localStorage["devMode"] = this.checked;
 });


### PR DESCRIPTION
In this PR I added the auto mode to the options, which checks for an amphtml link as soon as the `<head>` is loaded, then it stops loading the full page and loads the AMP version instead. This method has a minimal overhead. I reformatted the code and fixed the typos too.